### PR TITLE
Fixing Dependency chain

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ var compilation = tsb.create({
     verbose: false
 });
 
-gulp.task("compile", ["lint", "clean"], function () {
+gulp.task("compile", ["lint"], function () {
     return gulp.src([sourcePaths.typescriptFiles, testPaths.typescriptFiles], { base: "." })
         .pipe(compilation())
         .pipe(gulp.dest(buildDirectory))
@@ -42,11 +42,7 @@ gulp.task("compile", ["lint", "clean"], function () {
         .pipe(istanbul.hookRequire());
 });
 
-gulp.task("build", ["compile"], function() {
-    fs.readdirSync(sourcePaths.tasksPath).filter(function (file) {
-        return fs.statSync(path.join(sourcePaths.tasksPath, file)).isDirectory();
-    }).forEach(copyTaskLib);
-    
+gulp.task("build", ["clean", "compile"], function() {
     return gulp.src(sourcePaths.copyFiles, { base: "." })
         .pipe(gulp.dest(buildDirectory));
 });
@@ -85,6 +81,9 @@ gulp.task("testci", ["build"], function() {
 });
 
 gulp.task("package", ["build", "gettasklib"], function(cb) {
+    fs.readdirSync(sourcePaths.tasksPath).filter(function (file) {
+        return fs.statSync(path.join(sourcePaths.tasksPath, file)).isDirectory();
+    }).forEach(copyTaskLib);
     createPackage(cb);
 });
 


### PR DESCRIPTION
Fixed gulp targets dependency chain, so that clean gets called for each build, which fixes unwanted build breaks

compile : depends on lint, clean
build: depends on  compile
test: depends on build
testci: depends on  build
package: depends on build gettasklib
default: depends on build
