### PR TITLE
Snapshot memory option

### DIFF
--- a/src/Tasks/vmOperations/task.json
+++ b/src/Tasks/vmOperations/task.json
@@ -142,6 +142,15 @@
             "helpMarkDown": "Name of the snapshot of the virtual machines."
         },
         {
+            "name": "snapshotMemory",
+            "type": "boolean",
+            "label": "Snapshot Memory",
+            "defaultValue": "true",
+            "required": false,
+            "visibleRule": "action = Take Snapshot of Virtual Machines",
+            "helpMarkDown": "Snapshot the virtual machine's memory."
+        },
+        {
             "name": "description",
             "type": "multiLine",
             "label": "Description",

--- a/src/Tasks/vmOperations/task.json
+++ b/src/Tasks/vmOperations/task.json
@@ -146,7 +146,7 @@
             "type": "boolean",
             "label": "Snapshot Memory",
             "defaultValue": "true",
-            "required": false,
+            "required": true,
             "visibleRule": "action = Take Snapshot of Virtual Machines",
             "helpMarkDown": "Snapshot the virtual machine's memory."
         },

--- a/src/Tasks/vmOperations/task.json
+++ b/src/Tasks/vmOperations/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "java"

--- a/src/Tasks/vmOperations/vmOperations.ts
+++ b/src/Tasks/vmOperations/vmOperations.ts
@@ -58,7 +58,7 @@ export class VmOperations {
                 break;
             case "Take Snapshot of Virtual Machines":
                 var snapshotName = tl.getInput("snapshotName", true);
-                var snapshotVMMemory = "true";
+                var snapshotVMMemory = tl.getInput("snapshotMemory", true);
                 var quiesceGuestFileSystem = "false";
                 var description: string = tl.getInput("description", false);
                 timeout = tl.getInput("timeout", false);

--- a/src/VMWare.md
+++ b/src/VMWare.md
@@ -71,6 +71,7 @@ Visual Studio Team Services or Team Foundation Server requires a service connect
     * **Virtual Machines Name**: Provide the names of one or more virtual machines. For multiple machines use a comma separated list, like VM1, VM2, VM3.
     * **Datacenter**: Enter the name of the **Datacenter**, where the virtual machines are located.
     * **Snapshot Name**: Enter the name of the snapshot. Note that for the revert and delete snapshot actions, the snapshot should exist for the virtual machines, else the task will error out.
+    * **Snapshot Memory**: Check this option to snapshot the virtual machine's memory.
     * **Description**: Optionally, provide a description for the **Take Snapshot of Virtual Machines** action, like $(Build.DefinitionName).$(Build.BuildNumber). This can be used to track the particular run of the build or release definition that created the snapshot.
     * **Wait Time**: Specify wait time in seconds for the Virtual Machine to be in deployment ready state.
     * **Skip Certificate Authority Check**: If the vCenter Server's certificate is self-signed then select this option to skip the validation of the certificate from a trusted certificate authority. To check if the self-signed certificate is installed on the vCenter Server open the VMware vSphere® Web Client in a Web browser and look for certificate error screen. The vSphere Web Client URL will be similar to https://devtestlab325.fabrikam.com/vsphere-client/. For best practices regarding the vCenter Server certificates see the [website](http://aka.ms/vcentercertificate).     

--- a/tests/Tasks/vmOperations/vmOperationsTests.ts
+++ b/tests/Tasks/vmOperations/vmOperationsTests.ts
@@ -145,6 +145,7 @@ describe("getCmdArgsForAction", (): void => {
 
     it("Should read snapshot name, snapshot vm memory, quiesce file system,description and timeout for create snapshot", (): void => {
         getInputStub.withArgs("snapshotName", true).returns("dummySnapshotName");
+        getInputStub.withArgs("snapshotMemory", true).returns("true");
         getInputStub.withArgs("description", false).returns("Sample description");
         getInputStub.withArgs("timeout", false).returns("1200");
 
@@ -154,13 +155,26 @@ describe("getCmdArgsForAction", (): void => {
         debugStub.should.have.been.calledOnce;
     });
 
+    it("Should read snapshot name, snapshot vm memory, quiesce file system,description and timeout for create snapshot", (): void => {
+        getInputStub.withArgs("snapshotName", true).returns("dummySnapshotName");
+        getInputStub.withArgs("snapshotMemory", true).returns("false");
+        getInputStub.withArgs("description", false).returns("Sample description");
+        getInputStub.withArgs("timeout", false).returns("1200");
+
+        var cmdArgs = vmOperations.VmOperations.getCmdArgsForAction("Take Snapshot of Virtual Machines");
+
+        cmdArgs.should.contain("-snapshotOps create -snapshotName \"dummySnapshotName\" -snapshotVMMemory false -quiesceGuestFileSystem false -description \"Sample description\" -timeout 1200");
+        debugStub.should.have.been.calledOnce;
+    });
+
     it("Should not throw on failure to read description for create snapshot action", (): void => {
         getInputStub.withArgs("snapshotName", true).returns("dummySnapshotName");
+        getInputStub.withArgs("snapshotMemory", true).returns("true");
 
         var cmdArgs = vmOperations.VmOperations.getCmdArgsForAction("Take Snapshot of Virtual Machines");
 
         cmdArgs.should.contain("-snapshotOps create -snapshotName \"dummySnapshotName\" -snapshotVMMemory true -quiesceGuestFileSystem false -description \"undefined\"");
-        getInputStub.should.have.callCount(3);
+        getInputStub.should.have.callCount(4);
     });
 
     it("Should read snapshot name for restore snapshot action and timeout", (): void => {


### PR DESCRIPTION
Added option for user to snapshot the VM memory, or not.
Defaults to snapshot the VM memory, but can be disabled in the task settings.

Also updated the documentation. Couldn't snap a screenshot that was identical to the once originally used, so the screenshots might still need to be updated.