### PR TITLE
Added functionality to clone into folders.

### DIFF
--- a/src/Tasks/vmOperations/task.json
+++ b/src/Tasks/vmOperations/task.json
@@ -31,7 +31,7 @@
             "helpMarkDown": "VMware vCenter Server connection to target for deployment."
         },
         {
-            "name": "action", 
+            "name": "action",
             "type": "pickList",
             "label": "Action",
             "defaultValue": "Deploy Virtual Machines using Template",
@@ -72,6 +72,15 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Name of the Datacenter where the virtual machines are present or needs to be created."
+        },
+        {
+            "name": "targetFolder",
+            "type": "string",
+            "label": "Folder",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "action = Deploy Virtual Machines using Template",
+            "helpMarkDown": "Name of the Folder where the virtual machines need to be created. Use '/' to delimit subfolders."
         },
         {
             "name": "computeType",
@@ -159,13 +168,13 @@
             "visibleRule": "action = Take Snapshot of Virtual Machines || action = Deploy Virtual Machines using Template",
             "helpMarkDown": "Provide a description for the action."
         },
-        { 
-            "name": "timeout", 
-            "type": "string", 
+        {
+            "name": "timeout",
+            "type": "string",
             "label": "Wait Time",
-            "defaultValue": "600", 
+            "defaultValue": "600",
             "required": false,
-            "helpMarkDown": "Specify wait time in seconds for the Virtual Machine to be in deployment ready state.", 
+            "helpMarkDown": "Specify wait time in seconds for the Virtual Machine to be in deployment ready state.",
             "visibleRule": "action = Power On Virtual Machines || action = Shutdown Virtual Machines || action = Take Snapshot of Virtual Machines || action = Revert Snapshot of Virtual Machines || action = Deploy Virtual Machines using Template"
         },
         {

--- a/src/Tasks/vmOperations/vmOperations.ts
+++ b/src/Tasks/vmOperations/vmOperations.ts
@@ -33,6 +33,7 @@ export class VmOperations {
         switch (actionName) {
             case "Deploy Virtual Machines using Template":
                 var template = tl.getInput("template", true);
+                var folder = tl.getInput("targetFolder", false);
                 var computeType = tl.getInput("computeType", true);
                 var datastore = tl.getInput("datastore", true);
                 var description = tl.getInput("description", false);
@@ -53,7 +54,7 @@ export class VmOperations {
                         tl.error("Invalid compute type : " + computeType);
                         tl.exit(1);
                 }
-                cmdArgs += " -clonetemplate \"" + template  + "\" -computetype \"" + computeType + "\" -computename \"" +
+                cmdArgs += " -clonetemplate \"" + template  + "\" -computetype \"" + computeType + "\" -folder \"" + folder + "\" -computename \"" +
                         computeName + "\" -datastore \"" + datastore + "\" -customizationspec \"" + customizationspec + "\" -description \"" + description + "\" -timeout " + timeout;
                 break;
             case "Take Snapshot of Virtual Machines":

--- a/src/Tools/vmOpsTool/Constants.java
+++ b/src/Tools/vmOpsTool/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     public static final String CLONE_TEMPLATE = "-clonetemplate";
     public static final String POWER_OPS = "-powerops";
     public static final String TARGET_DC = "-targetdc";
+    public static final String FOLDER = "-folder";
     public static final String COMPUTE_TYPE = "-computetype";
     public static final String COMPUTE_NAME = "-computename";
     public static final String DATASTORE = "-datastore";

--- a/src/Tools/vmOpsTool/IVMWare.java
+++ b/src/Tools/vmOpsTool/IVMWare.java
@@ -71,6 +71,7 @@ public interface IVMWare {
     /**
      * @param templateName name of the virtual machine template to be cloned
      * @param vmName       name of the virtual machine
+     * @param folder       name of the target folder
      * @param computeType  type of the compute esxi/cluster/resourcepool
      * @param computeName  name of the compute resouce
      * @param description  optional description for create operation
@@ -79,7 +80,7 @@ public interface IVMWare {
      * @param connData       connection information for vCenter
      * @throws Exception
      */
-    void cloneVMFromTemplate(String templateName, String vmName, String computeType, String computeName, String datastore, String customizationSpec, String description, int timeout, ConnectionData connData) throws Exception;
+    void cloneVMFromTemplate(String templateName, String vmName, String folder, String computeType, String computeName, String datastore, String customizationSpec, String description, int timeout, ConnectionData connData) throws Exception;
 
     /**
      * @param vmName   name of the virtual machine

--- a/src/Tools/vmOpsTool/VmOpsTool.java
+++ b/src/Tools/vmOpsTool/VmOpsTool.java
@@ -189,6 +189,7 @@ public class VmOpsTool {
     private String executeCloneVmAction(Map<String, String> argsMap, String vmName, ConnectionData connData) throws Exception {
         String failedVm = "";
         String templateName = argsMap.get(Constants.CLONE_TEMPLATE);
+        String folder = argsMap.get(Constants.FOLDER);
         String computeType = argsMap.get(Constants.COMPUTE_TYPE);
         String computeName = argsMap.get(Constants.COMPUTE_NAME);
         String datastore = argsMap.get(Constants.DATASTORE);
@@ -197,7 +198,7 @@ public class VmOpsTool {
         int timeout = parseTimeout(argsMap.get(Constants.TIMEOUT));
 
         try {
-            vmwareFactory.call().cloneVMFromTemplate(templateName, vmName, computeType, computeName, datastore,
+            vmwareFactory.call().cloneVMFromTemplate(templateName, vmName, folder, computeType, computeName, datastore, 
                     customizationspec, description, timeout, connData);
         } catch (Exception exp) {
             System.out.println(exp.getMessage() != null ? exp.getMessage() : "Unknown error occurred.");

--- a/tests/Tools/vmOpsTool/InMemoryVMWareImpl.java
+++ b/tests/Tools/vmOpsTool/InMemoryVMWareImpl.java
@@ -164,7 +164,7 @@ public class InMemoryVMWareImpl implements IVMWare {
         }
     }
 
-    public synchronized void cloneVMFromTemplate(String templateName, String vmName, String computeType, String computeName,
+    public synchronized void cloneVMFromTemplate(String templateName, String vmName, String folder, String computeType, String computeName,
                                                  String datastore, String customizationSpec, String description, int timeout, ConnectionData connData) throws Exception {
         if (vmName.equals("VMNameThatFailsInClone")) {
             throw new Exception("Clone VM from template operation failed for VMNameThatFailsInClone");

--- a/tests/Tools/vmOpsTool/VMWarePlatformTests.java
+++ b/tests/Tools/vmOpsTool/VMWarePlatformTests.java
@@ -30,13 +30,14 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithTargetComputeAsESXiHostShouldSucceed() throws Exception {
         String newVmName = "newVmOnEsxiHost";
         String targetDC = "redmonddc";
+        String targetFolder = "";
         String computeType = "ESXi Host";
         String computeName = "idcvstt-lab318.corp.microsoft.com";
         String datastore = "datastore1";
         String description = "Creating new VM from ubuntuVM template on ESXi host";
         connData.setTargetDC(targetDC);
 
-        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
 
         assertThat(vmWareImpl.isVMExists(newVmName, connData)).isEqualTo(true);
 
@@ -49,13 +50,14 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithTargetComputeAsClusterShouldSucceed() throws Exception {
         String newVmName = "newVmOnCluster";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Cluster";
         String computeName = "fareastcluster";
         String datastore = "SharedStorage";
         String description = "Creating new VM from ubuntuVM template on cluster";
         connData.setTargetDC(targetDC);
 
-        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
 
         assertThat(vmWareImpl.isVMExists(newVmName, connData)).isEqualTo(true);
 
@@ -68,13 +70,14 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithTargetComputeAsResourcePoolShouldSucceed() throws Exception {
         String newVmName = "newVmOnResourcePool";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Resource Pool";
         String computeName = "fareastrp";
         String datastore = "SharedStorage";
         String description = "Creating new VM from ubuntuVM template on resource pool";
         connData.setTargetDC(targetDC);
 
-        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+        vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
 
         assertThat(vmWareImpl.isVMExists(newVmName, connData)).isEqualTo(true);
 
@@ -87,6 +90,7 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithInvalidTargetComputeShouldFail() throws Exception {
         String newVmName = "newVM";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Invalid Compute";
         String computeName = "fareastrp";
         String datastore = "datastore2";
@@ -95,7 +99,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }
@@ -107,6 +111,7 @@ public abstract class VMWarePlatformTests {
         String newVmName = "newVM";
         String nonExistingTemplate = "InvalidTemplate";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Resource Pool";
         String computeName = "fareastrp";
         String datastore = "datastore2";
@@ -115,7 +120,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(nonExistingTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(nonExistingTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }
@@ -126,6 +131,7 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithNonExistingTargetDatacenterShouldFail() throws Exception {
         String newVmName = "newVM";
         String targetDC = "InvalidDc";
+        String targetFolder = "";
         String computeType = "Resource Pool";
         String computeName = "fareastrp";
         String datastore = "datastore1";
@@ -134,7 +140,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }
@@ -145,6 +151,7 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithNonExistingTargetESXiShouldFail() {
         String newVmName = "newVM";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "ESXi Host";
         String computeName = "InvalidHost";
         String datastore = "datastore1";
@@ -153,7 +160,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }
@@ -164,6 +171,7 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithNonExistingTargetCloudShouldFail() {
         String newVmName = "newVM";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Cluster";
         String computeName = "InvalidCluster";
         String datastore = "datastore1";
@@ -172,7 +180,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }
@@ -183,6 +191,7 @@ public abstract class VMWarePlatformTests {
     public void cloneVMFromTemplateWithNonExistingTargetResourcePoolShouldFail() {
         String newVmName = "newVM";
         String targetDC = "fareastdc";
+        String targetFolder = "";
         String computeType = "Resource Pool";
         String computeName = "InvalidRp";
         String datastore = "datastore1";
@@ -191,7 +200,7 @@ public abstract class VMWarePlatformTests {
 
         Exception exp = null;
         try {
-            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
+            vmWareImpl.cloneVMFromTemplate(ubuntuTemplate, newVmName, targetFolder, computeType, computeName, datastore, linuxCustomizationSpec, description, 1200, connData);
         } catch (Exception e) {
             exp = e;
         }


### PR DESCRIPTION
Added the possibility to specify a folder when deploying a VM from a template.
If the user leaves the field empty, the VM is created directly under the datacenter (as in the current version).
Nested folders can be specified by using "/" as delimiter.

I tested the feature on a vCenter 5.5. 